### PR TITLE
linearMMSE nested parfor fix

### DIFF
--- a/linearMMSE.m
+++ b/linearMMSE.m
@@ -167,7 +167,7 @@ classdef linearMMSE < handle
                 
                 case 'zonal'
                     
-                    if matlabpool('size')==0
+                    if matlabpool('size')==0 && isempty(getCurrentJob) ~= 0
                         matlabpool('open')
                         poolWasAlreadyOpen = false;
                     end


### PR DESCRIPTION
linearMMSE.m line 171 updated with a further check if matlabpool has already been created by a parent to the worker.
